### PR TITLE
Upgrade mocha to version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	"devDependencies": {
 		"jscs": "^2",
 		"jshint": "^2",
-		"mocha": "^2",
+		"mocha": "^3",
 		"proclaim": "^3",
 		"request": "^2"
 	},


### PR DESCRIPTION
This fixes a security vuln with versions of minimatch older than
3.0.2. Minimatch is one of mocha's dependencies.

Older versions of minimatch (0.3.0 and 2.0.10, both vulnerable) are
still being pulled as dependencies of jshint. Jshint has fixed this
in master but a new version containing the fix hasn't been released
yet.

This shouldn't be much of a problem in production environments
anyway, as they are both devDependencies.