### PR TITLE
headers and hideElements

### DIFF
--- a/model/task.js
+++ b/model/task.js
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
-/*jshint maxcomplexity:7*/
+/*jshint maxcomplexity:10*/
 
 'use strict';
 
@@ -171,6 +171,18 @@ module.exports = function(app, callback) {
 							}
 						};
 					}
+					if (task.headers) {
+						if (pa11yOptions.page) {
+							pa11yOptions.page.headers = task.headers;
+						} else {
+							pa11yOptions.page = {
+								headers: task.headers
+							};
+						}
+					}
+					if (task.hideElements) {
+						pa11yOptions.hideElements = task.hideElements;
+					}
 
 					async.waterfall([
 
@@ -213,6 +225,12 @@ module.exports = function(app, callback) {
 				}
 				if (task.password) {
 					output.password = task.password;
+				}
+				if (task.hideElements) {
+					output.hideElements = task.hideElements;
+				}
+				if (task.headers) {
+					output.headers = task.headers;
 				}
 				return output;
 			}

--- a/route/task.js
+++ b/route/task.js
@@ -105,7 +105,9 @@ module.exports = function(app) {
 					ignore: Joi.array(),
 					comment: Joi.string(),
 					username: Joi.string().allow(''),
-					password: Joi.string().allow('')
+					password: Joi.string().allow(''),
+					hideElements: Joi.string().allow(''),
+					headers: Joi.string().allow('')
 				}
 			}
 		}

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -93,7 +93,9 @@ module.exports = function(app) {
 						'WCAG2AA',
 						'WCAG2AAA'
 					]),
-					ignore: Joi.array()
+					ignore: Joi.array(),
+					hideElements: Joi.string().allow(''),
+					headers: Joi.string().allow('')
 				}
 			}
 		}

--- a/test/integration/create-task.js
+++ b/test/integration/create-task.js
@@ -205,6 +205,102 @@ describe('POST /tasks', function() {
 
 	});
 
+	describe('with valid JSON and hideElements', function() {
+		var newTask;
+
+		beforeEach(function(done) {
+			newTask = {
+				name: 'NPG Home',
+				url: 'nature.com',
+				timeout: '30000',
+				wait: 1000,
+				standard: 'WCAG2AA',
+				hideElements: '.text-gray-light,.full-width'
+			};
+			var req = {
+				method: 'POST',
+				endpoint: 'tasks',
+				body: newTask
+			};
+			this.navigate(req, done);
+		});
+
+		it('should add the new task to the database', function(done) {
+			this.app.model.task.collection.findOne(newTask, function(err, task) {
+				assert.isDefined(task);
+				done(err);
+			});
+		});
+
+		it('should send a 201 status', function() {
+			assert.strictEqual(this.last.status, 201);
+		});
+
+		it('should send a location header pointing to the new task', function() {
+			var taskUrl = 'http://' + this.last.request.uri.host + '/tasks/' + this.last.body.id;
+			assert.strictEqual(this.last.response.headers.location, taskUrl);
+		});
+
+		it('should output a JSON representation of the new task', function() {
+			assert.isDefined(this.last.body.id);
+			assert.strictEqual(this.last.body.name, newTask.name);
+			assert.strictEqual(this.last.body.url, newTask.url);
+			assert.strictEqual(this.last.body.standard, newTask.standard);
+			assert.deepEqual(this.last.body.wait, newTask.wait);
+			assert.deepEqual(this.last.body.hideElements, newTask.hideElements);
+			assert.deepEqual(this.last.body.ignore, []);
+		});
+
+	});
+
+	describe('with valid JSON and headers object', function() {
+		var newTask;
+
+		beforeEach(function(done) {
+			newTask = {
+				name: 'NPG Home',
+				url: 'nature.com',
+				timeout: '30000',
+				wait: 1000,
+				standard: 'WCAG2AA',
+				headers: '{"Cookie": "next-flags=ads:off; secure=true"}'
+			};
+			var req = {
+				method: 'POST',
+				endpoint: 'tasks',
+				body: newTask
+			};
+			this.navigate(req, done);
+		});
+
+		it('should add the new task to the database', function(done) {
+			this.app.model.task.collection.findOne(newTask, function(err, task) {
+				assert.isDefined(task);
+				done(err);
+			});
+		});
+
+		it('should send a 201 status', function() {
+			assert.strictEqual(this.last.status, 201);
+		});
+
+		it('should send a location header pointing to the new task', function() {
+			var taskUrl = 'http://' + this.last.request.uri.host + '/tasks/' + this.last.body.id;
+			assert.strictEqual(this.last.response.headers.location, taskUrl);
+		});
+
+		it('should output a JSON representation of the new task', function() {
+			assert.isDefined(this.last.body.id);
+			assert.strictEqual(this.last.body.name, newTask.name);
+			assert.strictEqual(this.last.body.url, newTask.url);
+			assert.strictEqual(this.last.body.standard, newTask.standard);
+			assert.deepEqual(this.last.body.wait, newTask.wait);
+			assert.deepEqual(this.last.body.headers, newTask.headers);
+			assert.deepEqual(this.last.body.ignore, []);
+		});
+
+	});
+
 	describe('with invalid name', function() {
 
 		beforeEach(function(done) {


### PR DESCRIPTION
@rowanmanning I've added `headers` and `hideElements` to the webservice. I'm in the process of adding input fields for them to the pa11y dashboard. We need these in our use case for:
- Modifying headers to fake different types of users being logged in
- Hiding ads