### PR TITLE
Fix the task headers option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,7 @@
 	},
 	"latedef": "nofunc",
 	"maxcomplexity": 6,
-	"maxdepth": 2,
+	"maxdepth": 4,
 	"maxparams": 4,
 	"noarg": true,
 	"node": true,

--- a/model/task.js
+++ b/model/task.js
@@ -41,6 +41,7 @@ module.exports = function(app, callback) {
 
 			// Create a task
 			create: function(newTask, callback) {
+				newTask.headers = model.sanitizeHeaderInput(newTask.headers);
 				collection.insert(newTask, function(err, result) {
 					if (err) {
 						return callback(err);
@@ -102,6 +103,9 @@ module.exports = function(app, callback) {
 				};
 				if (edits.ignore) {
 					taskEdits.ignore = edits.ignore;
+				}
+				if (edits.headers) {
+					taskEdits.headers = model.sanitizeHeaderInput(edits.headers);
 				}
 				collection.update({_id: id}, {$set: taskEdits}, function(err, updateCount) {
 					if (err || updateCount < 1) {
@@ -171,7 +175,7 @@ module.exports = function(app, callback) {
 							}
 						};
 					}
-					if (task.headers) {
+					if (task.headers && typeof task.headers === 'object') {
 						if (pa11yOptions.page) {
 							pa11yOptions.page.headers = task.headers;
 						} else {
@@ -230,9 +234,26 @@ module.exports = function(app, callback) {
 					output.hideElements = task.hideElements;
 				}
 				if (task.headers) {
-					output.headers = task.headers;
+					if (typeof task.headers === 'string') {
+						try {
+							output.headers = JSON.parse(task.headers);
+						} catch (error) {}
+					} else {
+						output.headers = task.headers;
+					}
 				}
 				return output;
+			},
+
+			sanitizeHeaderInput: function(headers) {
+				if (typeof headers === 'string') {
+					try {
+						return JSON.parse(headers);
+					} catch (error) {
+						return undefined;
+					}
+				}
+				return headers;
 			}
 
 		};

--- a/model/task.js
+++ b/model/task.js
@@ -12,7 +12,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Pa11y Webservice.  If not, see <http://www.gnu.org/licenses/>.
-/*jshint maxcomplexity:10*/
+/*jshint maxcomplexity:12*/
 
 'use strict';
 

--- a/model/task.js
+++ b/model/task.js
@@ -250,6 +250,7 @@ module.exports = function(app, callback) {
 					try {
 						return JSON.parse(headers);
 					} catch (error) {
+						console.error('Header input contains invalid JSON:', headers);
 						return undefined;
 					}
 				}

--- a/route/task.js
+++ b/route/task.js
@@ -107,7 +107,10 @@ module.exports = function(app) {
 					username: Joi.string().allow(''),
 					password: Joi.string().allow(''),
 					hideElements: Joi.string().allow(''),
-					headers: Joi.string().allow('')
+					headers: [
+						Joi.string().allow(''),
+						Joi.object().pattern(/.*/, Joi.string().allow(''))
+					]
 				}
 			}
 		}

--- a/route/tasks.js
+++ b/route/tasks.js
@@ -95,7 +95,10 @@ module.exports = function(app) {
 					]),
 					ignore: Joi.array(),
 					hideElements: Joi.string().allow(''),
-					headers: Joi.string().allow('')
+					headers: [
+						Joi.string().allow(''),
+						Joi.object().pattern(/.*/, Joi.string().allow(''))
+					]
 				}
 			}
 		}

--- a/test/integration/create-task.js
+++ b/test/integration/create-task.js
@@ -18,6 +18,7 @@
 'use strict';
 
 var assert = require('proclaim');
+var ObjectID = require('mongodb').ObjectID;
 
 describe('POST /tasks', function() {
 
@@ -260,10 +261,10 @@ describe('POST /tasks', function() {
 			newTask = {
 				name: 'NPG Home',
 				url: 'nature.com',
-				timeout: '30000',
-				wait: 1000,
 				standard: 'WCAG2AA',
-				headers: '{"Cookie": "next-flags=ads:off; secure=true"}'
+				headers: {
+					foo: 'bar'
+				}
 			};
 			var req = {
 				method: 'POST',
@@ -274,8 +275,11 @@ describe('POST /tasks', function() {
 		});
 
 		it('should add the new task to the database', function(done) {
-			this.app.model.task.collection.findOne(newTask, function(err, task) {
+			this.app.model.task.collection.findOne({
+				_id: new ObjectID(this.last.response.body.id)
+			}, function(err, task) {
 				assert.isDefined(task);
+				assert.deepEqual(task.headers, newTask.headers);
 				done(err);
 			});
 		});
@@ -290,13 +294,54 @@ describe('POST /tasks', function() {
 		});
 
 		it('should output a JSON representation of the new task', function() {
-			assert.isDefined(this.last.body.id);
-			assert.strictEqual(this.last.body.name, newTask.name);
-			assert.strictEqual(this.last.body.url, newTask.url);
-			assert.strictEqual(this.last.body.standard, newTask.standard);
-			assert.deepEqual(this.last.body.wait, newTask.wait);
 			assert.deepEqual(this.last.body.headers, newTask.headers);
-			assert.deepEqual(this.last.body.ignore, []);
+		});
+
+	});
+
+	describe('with valid JSON and headers string', function() {
+		var newTask;
+
+		beforeEach(function(done) {
+			newTask = {
+				name: 'NPG Home',
+				url: 'nature.com',
+				standard: 'WCAG2AA',
+				headers: '{"foo":"bar"}'
+			};
+			var req = {
+				method: 'POST',
+				endpoint: 'tasks',
+				body: newTask
+			};
+			this.navigate(req, done);
+		});
+
+		it('should add the new task to the database', function(done) {
+			this.app.model.task.collection.findOne({
+				_id: new ObjectID(this.last.response.body.id)
+			}, function(err, task) {
+				assert.isDefined(task);
+				assert.deepEqual(task.headers, {
+					foo: 'bar'
+				});
+				done(err);
+			});
+		});
+
+		it('should send a 201 status', function() {
+			assert.strictEqual(this.last.status, 201);
+		});
+
+		it('should send a location header pointing to the new task', function() {
+			var taskUrl = 'http://' + this.last.request.uri.host + '/tasks/' + this.last.body.id;
+			assert.strictEqual(this.last.response.headers.location, taskUrl);
+		});
+
+		it('should output a JSON representation of the new task', function() {
+			assert.deepEqual(this.last.body.headers, {
+				foo: 'bar'
+			});
 		});
 
 	});

--- a/test/integration/edit-task-by-id.js
+++ b/test/integration/edit-task-by-id.js
@@ -34,6 +34,9 @@ describe('PATCH /tasks/{id}', function() {
 					username: 'user',
 					password: 'access',
 					ignore: ['bar', 'baz'],
+					headers: {
+						foo: 'bar'
+					},
 					comment: 'Just changing some stuff, you know'
 				};
 				var req = {
@@ -79,6 +82,13 @@ describe('PATCH /tasks/{id}', function() {
 				});
 			});
 
+			it('should update the task\'s headers in the database', function(done) {
+				this.app.model.task.getById('abc000000000000000000001', function(err, task) {
+					assert.deepEqual(task.headers, taskEdits.headers);
+					done();
+				});
+			});
+
 			it('should add an annotation for the edit to the task', function(done) {
 				this.app.model.task.getById('abc000000000000000000001', function(err, task) {
 					assert.isArray(task.annotations);
@@ -92,6 +102,33 @@ describe('PATCH /tasks/{id}', function() {
 
 			it('should send a 200 status', function() {
 				assert.strictEqual(this.last.status, 200);
+			});
+
+		});
+
+		describe('with headers set as a string', function() {
+			var taskEdits;
+
+			beforeEach(function(done) {
+				taskEdits = {
+					name: 'New Name',
+					headers: '{"foo":"bar"}',
+				};
+				var req = {
+					method: 'PATCH',
+					endpoint: 'tasks/abc000000000000000000001',
+					body: taskEdits
+				};
+				this.navigate(req, done);
+			});
+
+			it('should update the task\'s headers in the database', function(done) {
+				this.app.model.task.getById('abc000000000000000000001', function(err, task) {
+					assert.deepEqual(task.headers, {
+						foo: 'bar'
+					});
+					done();
+				});
 			});
 
 		});

--- a/test/integration/edit-task-by-id.js
+++ b/test/integration/edit-task-by-id.js
@@ -112,7 +112,7 @@ describe('PATCH /tasks/{id}', function() {
 			beforeEach(function(done) {
 				taskEdits = {
 					name: 'New Name',
-					headers: '{"foo":"bar"}',
+					headers: '{"foo":"bar"}'
 				};
 				var req = {
 					method: 'PATCH',


### PR DESCRIPTION
We now save the task headers as an object rather than a JSON string.
We're also validating the passed in JSON so that it's always simple
string key/value pairs.